### PR TITLE
주문 프로젝트의 파트너에 대한 도메인을 작성

### DIFF
--- a/src/main/java/dev/project/order/common/util/TokenGenerator.java
+++ b/src/main/java/dev/project/order/common/util/TokenGenerator.java
@@ -1,0 +1,15 @@
+package dev.project.order.common.util;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+public class TokenGenerator {
+    private static final int TOKEN_LENGTH = 20;
+
+    public static String randomCharacter(int length) {
+        return RandomStringUtils.randomAlphanumeric(length);
+    }
+
+    public static String randomCharacterWithPrefix(String prefix) {
+        return prefix + randomCharacter(TOKEN_LENGTH - prefix.length());
+    }
+}

--- a/src/main/java/dev/project/order/domain/AbstractEntity.java
+++ b/src/main/java/dev/project/order/domain/AbstractEntity.java
@@ -1,0 +1,22 @@
+package dev.project.order.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class AbstractEntity {
+
+    @CreationTimestamp
+    private ZonedDateTime createdAt;
+
+    @UpdateTimestamp
+    private ZonedDateTime updatedAt;
+}

--- a/src/main/java/dev/project/order/domain/partner/Partner.java
+++ b/src/main/java/dev/project/order/domain/partner/Partner.java
@@ -1,0 +1,66 @@
+package dev.project.order.domain.partner;
+
+import dev.project.order.common.util.TokenGenerator;
+import dev.project.order.domain.AbstractEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+@Slf4j
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "partners")
+public class Partner extends AbstractEntity {
+
+    private static final String PREFIX_PARTNER = "ptn_";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String partnerToken;
+
+    private String partnerName;
+    private String businessNo;
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+
+    @Builder
+    public Partner(String partnerName, String email, String businessNo) {
+        if (StringUtils.isEmpty(partnerName)) throw new RuntimeException("empty PartnerName");
+        if (StringUtils.isEmpty(businessNo)) throw new RuntimeException("empty BusinessNo");
+        if (StringUtils.isEmpty(email)) throw new RuntimeException("empty Email");
+
+
+        this.partnerToken = TokenGenerator.randomCharacterWithPrefix(PREFIX_PARTNER);
+        this.partnerName = partnerName;
+        this.email = email;
+        this.businessNo = businessNo;
+        this.status = Status.ENABLE;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum Status {
+        ENABLE("활성화"),
+        DISABLE("비활성화");
+
+        private final String description;
+    }
+
+    public void enable() {
+        this.status = Status.ENABLE;
+    }
+
+    public void disable() {
+        this.status = Status.DISABLE;
+    }
+}


### PR DESCRIPTION
> PR 개요
- 주문 프로젝트의 주요 도메인 중 하나인 `파트너` 도메인을 작성

> 작업 상세내용
- `파트너`도메인의 명세 구현
- 모든 도메인에서 사용 가능한 메타데이터(`createdAt`, `updatedAt`)를 구현 후 각 도메인에서 상속하여 사용하도록 설정
- 파트너 도메인의 대체키를 사용하기 위한 common.util.`TokenGenerator` 구현
  - 랜덤 스트링의 대체키를 생성하기 위한 클래스
  - 파트너 도메인에서는 prefix로 `ptn_` 사용

This referenced #3 
Parent branch is `feature/partner`