### PR TITLE
주문 프로젝트의 파트너에 대한 서비스를 구현

### DIFF
--- a/src/main/java/dev/project/order/common/exception/BaseException.java
+++ b/src/main/java/dev/project/order/common/exception/BaseException.java
@@ -1,0 +1,34 @@
+package dev.project.order.common.exception;
+
+import dev.project.order.common.response.ErrorCode;
+import lombok.Getter;
+
+/**
+ * BaseException 또는 BaseException 을 확장한 Exception 은
+ * 서비스 운영에서 예상이 가능한 Exception 을 표현한다.
+ *
+ * 그렇기 때문에 http status: 200 이면서 result: FAIL 을 표현하고
+ * 특정 ErrorCode 만 alert 를 포함한 모니터링 대상으로 한다.
+ */
+@Getter
+public class BaseException extends RuntimeException {
+    private ErrorCode errorCode;
+
+    public BaseException() {
+    }
+
+    public BaseException(ErrorCode errorCode) {
+        super(errorCode.getErrorMsg());
+        this.errorCode = errorCode;
+    }
+
+    public BaseException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BaseException(String message, ErrorCode errorCode, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/dev/project/order/common/exception/EntityNotFoundException.java
+++ b/src/main/java/dev/project/order/common/exception/EntityNotFoundException.java
@@ -1,0 +1,14 @@
+package dev.project.order.common.exception;
+
+import dev.project.order.common.response.ErrorCode;
+
+public class EntityNotFoundException extends BaseException {
+
+    public EntityNotFoundException() {
+        super(ErrorCode.COMMON_INVALID_PARAMETER);
+    }
+
+    public EntityNotFoundException(String message) {
+        super(message, ErrorCode.COMMON_INVALID_PARAMETER);
+    }
+}

--- a/src/main/java/dev/project/order/common/exception/IllegalStatusException.java
+++ b/src/main/java/dev/project/order/common/exception/IllegalStatusException.java
@@ -1,0 +1,15 @@
+package dev.project.order.common.exception;
+
+
+import dev.project.order.common.response.ErrorCode;
+
+public class IllegalStatusException extends BaseException {
+
+    public IllegalStatusException() {
+        super(ErrorCode.COMMON_ILLEGAL_STATUS);
+    }
+
+    public IllegalStatusException(String message) {
+        super(message, ErrorCode.COMMON_ILLEGAL_STATUS);
+    }
+}

--- a/src/main/java/dev/project/order/common/exception/InvalidParamException.java
+++ b/src/main/java/dev/project/order/common/exception/InvalidParamException.java
@@ -1,0 +1,22 @@
+package dev.project.order.common.exception;
+
+import dev.project.order.common.response.ErrorCode;
+
+public class InvalidParamException extends BaseException {
+
+    public InvalidParamException() {
+        super(ErrorCode.COMMON_INVALID_PARAMETER);
+    }
+
+    public InvalidParamException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public InvalidParamException(String errorMsg) {
+        super(errorMsg, ErrorCode.COMMON_INVALID_PARAMETER);
+    }
+
+    public InvalidParamException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/dev/project/order/common/response/ErrorCode.java
+++ b/src/main/java/dev/project/order/common/response/ErrorCode.java
@@ -1,0 +1,23 @@
+package dev.project.order.common.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    COMMON_SYSTEM_ERROR("일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."), // 장애 상황
+    COMMON_INVALID_PARAMETER("요청한 값이 올바르지 않습니다."),
+    COMMON_ENTITY_NOT_FOUND("존재하지 않는 엔티티입니다."),
+    COMMON_ILLEGAL_STATUS("잘못된 상태값입니다."),
+
+    // GIFT
+    GIFT_NOT_RECEIVABLE_CONDITION("선물 수락이 가능한 상태가 아닙니다."),
+    GIFT_NOT_MODIFY_DELIVERY_CONDITION("배송지 변경이 가능한 상태가 아닙니다.");
+
+    private final String errorMsg;
+
+    public String getErrorMsg(Object... arg) {
+        return String.format(errorMsg, arg);
+    }
+}

--- a/src/main/java/dev/project/order/domain/partner/PartnerCommand.java
+++ b/src/main/java/dev/project/order/domain/partner/PartnerCommand.java
@@ -1,0 +1,22 @@
+package dev.project.order.domain.partner;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@Builder
+public class PartnerCommand {
+    private final String partnerName;
+    private final String businessNo;
+    private final String email;
+
+    public Partner toEntity() {
+        return Partner.builder()
+                .partnerName(getPartnerName())
+                .businessNo(getBusinessNo())
+                .email(getEmail())
+                .build();
+    }
+}

--- a/src/main/java/dev/project/order/domain/partner/PartnerInfo.java
+++ b/src/main/java/dev/project/order/domain/partner/PartnerInfo.java
@@ -1,0 +1,24 @@
+package dev.project.order.domain.partner;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PartnerInfo {
+
+    private final Long id;
+    private final String partnerToken;
+    private final String partnerName;
+    private final String businessNo;
+    private final String email;
+    private final Partner.Status status;
+
+    public PartnerInfo(Partner partner) {
+        this.id = partner.getId();
+        this.partnerToken = partner.getPartnerToken();
+        this.partnerName = partner.getPartnerName();
+        this.businessNo = partner.getBusinessNo();
+        this.email = partner.getEmail();
+        this.status = partner.getStatus();
+    }
+}

--- a/src/main/java/dev/project/order/domain/partner/PartnerReader.java
+++ b/src/main/java/dev/project/order/domain/partner/PartnerReader.java
@@ -1,0 +1,5 @@
+package dev.project.order.domain.partner;
+
+public interface PartnerReader {
+    Partner getPartner(String partnerToken);
+}

--- a/src/main/java/dev/project/order/domain/partner/PartnerService.java
+++ b/src/main/java/dev/project/order/domain/partner/PartnerService.java
@@ -1,0 +1,10 @@
+package dev.project.order.domain.partner;
+
+public interface PartnerService {
+    // Command, Criteria --- info
+
+    PartnerInfo registerPartner(PartnerCommand command);
+    PartnerInfo getPartnerInfo(String partnerToken);
+    PartnerInfo enablePartner(String partnerToken);
+    PartnerInfo disablePartner(String partnerToken);
+}

--- a/src/main/java/dev/project/order/domain/partner/PartnerServiceImpl.java
+++ b/src/main/java/dev/project/order/domain/partner/PartnerServiceImpl.java
@@ -1,0 +1,54 @@
+package dev.project.order.domain.partner;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class PartnerServiceImpl implements PartnerService {
+
+    private final PartnerStore partnerStore;
+    private final PartnerReader partnerReader;
+
+    @Override
+    @Transactional
+    public PartnerInfo registerPartner(PartnerCommand command) {
+
+        var initPartner = command.toEntity();
+        Partner partner = partnerStore.store(initPartner);
+
+        return new PartnerInfo(partner);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PartnerInfo getPartnerInfo(String partnerToken) {
+
+        Partner partner = partnerReader.getPartner(partnerToken);
+
+        return new PartnerInfo(partner);
+    }
+
+    @Override
+    @Transactional
+    public PartnerInfo enablePartner(String partnerToken) {
+
+        Partner partner = partnerReader.getPartner(partnerToken);
+        partner.enable();
+
+        return new PartnerInfo(partner);
+    }
+
+    @Override
+    @Transactional
+    public PartnerInfo disablePartner(String partnerToken) {
+
+        Partner partner = partnerReader.getPartner(partnerToken);
+        partner.disable();
+
+        return new PartnerInfo(partner);
+    }
+}

--- a/src/main/java/dev/project/order/domain/partner/PartnerStore.java
+++ b/src/main/java/dev/project/order/domain/partner/PartnerStore.java
@@ -1,0 +1,6 @@
+package dev.project.order.domain.partner;
+
+public interface PartnerStore {
+
+    Partner store(Partner initPartner);
+}

--- a/src/main/java/dev/project/order/infrastructure/partner/PartnerReaderImpl.java
+++ b/src/main/java/dev/project/order/infrastructure/partner/PartnerReaderImpl.java
@@ -1,0 +1,22 @@
+package dev.project.order.infrastructure.partner;
+
+import dev.project.order.common.exception.EntityNotFoundException;
+import dev.project.order.domain.partner.Partner;
+import dev.project.order.domain.partner.PartnerReader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class PartnerReaderImpl implements PartnerReader {
+
+    private final PartnerRepository partnerRepository;
+
+    @Override
+    public Partner getPartner(String partnerToken) {
+        return partnerRepository.findByPartnerToken(partnerToken)
+                .orElseThrow(EntityNotFoundException::new);
+    }
+}

--- a/src/main/java/dev/project/order/infrastructure/partner/PartnerRepository.java
+++ b/src/main/java/dev/project/order/infrastructure/partner/PartnerRepository.java
@@ -1,0 +1,11 @@
+package dev.project.order.infrastructure.partner;
+
+import dev.project.order.domain.partner.Partner;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PartnerRepository extends JpaRepository<Partner, Long> {
+
+    Optional<Partner> findByPartnerToken(String partnerToken);
+}

--- a/src/main/java/dev/project/order/infrastructure/partner/PartnerStoreImpl.java
+++ b/src/main/java/dev/project/order/infrastructure/partner/PartnerStoreImpl.java
@@ -1,0 +1,28 @@
+package dev.project.order.infrastructure.partner;
+
+import dev.project.order.common.exception.InvalidParamException;
+import dev.project.order.domain.partner.Partner;
+import dev.project.order.domain.partner.PartnerStore;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class PartnerStoreImpl implements PartnerStore {
+
+    private final PartnerRepository partnerRepository;
+
+    @Override
+    public Partner store(Partner partner) {
+        if (StringUtils.isEmpty(partner.getPartnerToken())) throw new InvalidParamException("partner.getPartnerToken()");
+        if (StringUtils.isEmpty(partner.getPartnerName())) throw new InvalidParamException("partner.getPartnerName()");
+        if (StringUtils.isEmpty(partner.getBusinessNo())) throw new InvalidParamException("partner.getBusinessNo()");
+        if (StringUtils.isEmpty(partner.getEmail())) throw new InvalidParamException("partner.getEmail()");
+        if (partner.getStatus() == null) throw new InvalidParamException("partner.getStatus()");
+
+        return partnerRepository.save(partner);
+    }
+}


### PR DESCRIPTION
> PR 개요
- 주문 프로젝트의 주요 도메인 중 하나인 `파트너`의 서비스를 구현

> 작업 상세내용
- 파트너 도메인의 비즈니스 로직을 담당하는 서비스를 구현
- Domain Layer에서는 Interface의 형태로 어떠한 구현을 담당하는지 명세를 작성
- 세부 구현은 Infrastructure Layer에서 Domain Layer의 Interface를 상속받아서 실행되도록 구현
  - Domain Layer의 서비스 Interface는 Entery Point로서 `@Service`로 명시
  - Infrastructure의 서비스는 실제 구현체임을 명시하기 위해 `@Component`로 선언
- 프로젝트에서 공통적으로 사용될 BusinessException을 구현
  - `common.exception`

This referenced #3 
Parent branch is `feature/partner`